### PR TITLE
CIP27: add royalties to nfts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,8 +69,8 @@ typings/
 .yarn-integrity
 
 # dotenv environment variables file
-.env
-.env.test
+.env*
+!.env.example
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/src/db/models.ts
+++ b/src/db/models.ts
@@ -185,6 +185,34 @@ export const CIP25MetadataBlock = CIP25Metadata.belongsTo(Block, {
 });
 Block.hasOne(CIP25Metadata);
 
+export class CIP27Royalty extends Model<
+  InferAttributes<CIP27Royalty>,
+  InferCreationAttributes<CIP27Royalty>
+> {
+  declare policyId: string;
+  declare rate: string;
+  declare addr: string;
+}
+
+CIP27Royalty.init(
+  {
+    policyId: {
+      type: DataTypes.STRING(56),
+      unique: true,
+      allowNull: false,
+    },
+    rate: DataTypes.STRING,
+    addr: DataTypes.STRING,
+  },
+  { sequelize }
+);
+
+export const CIP27RoyaltyBlock = CIP27Royalty.belongsTo(Block, {
+  onDelete: "CASCADE",
+  onUpdate: "CASCADE",
+});
+Block.hasOne(CIP27Royalty);
+
 /**
  * CIP 68 is annoying as there is no way to differentiate between different
  * metadata

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -43,10 +43,15 @@ export type Asset = {
   common: CommonMetadata;
   offchain?: Maybe<OffchainMetadata>;
   cip25?: Maybe<CIP25Metadata>;
+  /**
+   * In case there was a CIP27 Royalty information attached
+   * to the policy ID
+   */
+  royalty?: Maybe<Royalty>;
   /** CIP68 only defines how the data is stored and not their format */
   cip68nft?: Maybe<CIP25Metadata>;
   cip68ft?: Maybe<OffchainMetadata>;
-  /** Available total supply as BigInt */
+  /** Available total supply as stringified BigInt */
   supply?: Maybe<Scalars["String"]>;
   _dbId: Scalars["Int"];
 };
@@ -115,6 +120,26 @@ export type CIP25Metadata = {
    * Often the metadta would include some extra properties or ID
    */
   otherProperties?: Maybe<Scalars["String"]>;
+};
+
+/**
+ * Metadata coming from the CIP-27 standard
+ * https://cips.cardano.org/cips/cip27/
+ */
+export type Royalty = {
+  __typename?: "Royalty";
+  /**
+   * The "rate" key tag can be any floating point value from 0.0 to 1.0, to represent
+   * between 0 and 100 percent. For example, a 12.5 percent royalty would be
+   * represented with "rate": "0.125"
+   */
+  rate: Scalars["String"];
+  /**
+   * A single payment address.
+   * This payment address could be part of a smart contract, which should allow
+   * for greater flexibility of royalties distributions, controlled by the asset creator.
+   */
+  addr: Scalars["String"];
 };
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
@@ -190,6 +215,7 @@ export type ResolversTypes = {
   CommonMetadata: ResolverTypeWrapper<CommonMetadata>;
   OffchainMetadata: ResolverTypeWrapper<OffchainMetadata>;
   CIP25Metadata: ResolverTypeWrapper<CIP25Metadata>;
+  Royalty: ResolverTypeWrapper<Royalty>;
   Boolean: ResolverTypeWrapper<Scalars["Boolean"]>;
 };
 
@@ -203,6 +229,7 @@ export type ResolversParentTypes = {
   CommonMetadata: CommonMetadata;
   OffchainMetadata: OffchainMetadata;
   CIP25Metadata: CIP25Metadata;
+  Royalty: Royalty;
   Boolean: Scalars["Boolean"];
 };
 
@@ -229,6 +256,7 @@ export type AssetResolvers<
   common?: Resolver<ResolversTypes["CommonMetadata"], ParentType, ContextType>;
   offchain?: Resolver<Maybe<ResolversTypes["OffchainMetadata"]>, ParentType, ContextType>;
   cip25?: Resolver<Maybe<ResolversTypes["CIP25Metadata"]>, ParentType, ContextType>;
+  royalty?: Resolver<Maybe<ResolversTypes["Royalty"]>, ParentType, ContextType>;
   cip68nft?: Resolver<Maybe<ResolversTypes["CIP25Metadata"]>, ParentType, ContextType>;
   cip68ft?: Resolver<Maybe<ResolversTypes["OffchainMetadata"]>, ParentType, ContextType>;
   supply?: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
@@ -274,12 +302,22 @@ export type CIP25MetadataResolvers<
   isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type RoyaltyResolvers<
+  ContextType = MercuriusContext,
+  ParentType extends ResolversParentTypes["Royalty"] = ResolversParentTypes["Royalty"]
+> = {
+  rate?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  addr?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type Resolvers<ContextType = MercuriusContext> = {
   Query?: QueryResolvers<ContextType>;
   Asset?: AssetResolvers<ContextType>;
   CommonMetadata?: CommonMetadataResolvers<ContextType>;
   OffchainMetadata?: OffchainMetadataResolvers<ContextType>;
   CIP25Metadata?: CIP25MetadataResolvers<ContextType>;
+  Royalty?: RoyaltyResolvers<ContextType>;
 };
 
 export type Loader<TReturn, TObj, TParams, TContext> = (
@@ -310,6 +348,7 @@ export interface Loaders<
     common?: LoaderResolver<CommonMetadata, Asset, {}, TContext>;
     offchain?: LoaderResolver<Maybe<OffchainMetadata>, Asset, {}, TContext>;
     cip25?: LoaderResolver<Maybe<CIP25Metadata>, Asset, {}, TContext>;
+    royalty?: LoaderResolver<Maybe<Royalty>, Asset, {}, TContext>;
     cip68nft?: LoaderResolver<Maybe<CIP25Metadata>, Asset, {}, TContext>;
     cip68ft?: LoaderResolver<Maybe<OffchainMetadata>, Asset, {}, TContext>;
     supply?: LoaderResolver<Maybe<Scalars["String"]>, Asset, {}, TContext>;
@@ -340,6 +379,11 @@ export interface Loaders<
     mediaType?: LoaderResolver<Maybe<Scalars["String"]>, CIP25Metadata, {}, TContext>;
     description?: LoaderResolver<Maybe<Scalars["String"]>, CIP25Metadata, {}, TContext>;
     otherProperties?: LoaderResolver<Maybe<Scalars["String"]>, CIP25Metadata, {}, TContext>;
+  };
+
+  Royalty?: {
+    rate?: LoaderResolver<Scalars["String"], Royalty, {}, TContext>;
+    addr?: LoaderResolver<Scalars["String"], Royalty, {}, TContext>;
   };
 }
 declare module "mercurius" {

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -234,5 +234,18 @@ export const loaders: MercuriusLoaders = {
       const forgedByAsset = _.keyBy(forged, "AssetId");
       return queries.map(({ obj: asset }) => BigInt(forgedByAsset[asset._dbId]?.supply || 0).toString());
     },
+    async royalty(queries, ctx) {
+      const royalties = _.keyBy(
+        await ctx.db.CIP27Royalty.findAll({
+          where: {
+            policyId: {
+              [Op.in]: queries.map(({ obj: asset }) => asset.policyId),
+            },
+          },
+        }),
+        "policyId"
+      );
+      return queries.map(({ obj: asset }) => royalties[asset.policyId] || null);
+    },
   },
 };

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -18,13 +18,19 @@ export const schema = gql`
     cip25: CIP25Metadata
 
     """
+    In case there was a CIP27 Royalty information attached
+    to the policy ID
+    """
+    royalty: Royalty
+
+    """
     CIP68 only defines how the data is stored and not their format
     """
     cip68nft: CIP25Metadata
     cip68ft: OffchainMetadata
 
     """
-    Available total supply as BigInt
+    Available total supply as stringified BigInt
     """
     supply: String
 
@@ -136,5 +142,25 @@ export const schema = gql`
     Often the metadta would include some extra properties or ID
     """
     otherProperties: String
+  }
+
+  """
+  Metadata coming from the CIP-27 standard
+  https://cips.cardano.org/cips/cip27/
+  """
+  type Royalty {
+    """
+    The "rate" key tag can be any floating point value from 0.0 to 1.0, to represent
+    between 0 and 100 percent. For example, a 12.5 percent royalty would be
+    represented with "rate": "0.125"
+    """
+    rate: String!
+
+    """
+    A single payment address.
+    This payment address could be part of a smart contract, which should allow
+    for greater flexibility of royalties distributions, controlled by the asset creator.
+    """
+    addr: String!
   }
 `;

--- a/src/onchain/record.ts
+++ b/src/onchain/record.ts
@@ -6,6 +6,7 @@ import { Block } from "../db/models";
 import { logger } from "../logger";
 import { startChainSync } from "./chainSync";
 import { recordCIP25 } from "./recorders/cip25";
+import { recordCIP27 } from "./recorders/cip27";
 import { recordCIP68 } from "./recorders/cip68";
 import { recordForge } from "./recorders/forge";
 
@@ -29,7 +30,7 @@ export async function recordOnchainMetadata() {
 
   chainSyncClient = await startChainSync({
     points: [startPoint, options.onchain.syncFrom],
-    recorders: [recordCIP25, recordCIP68, recordForge],
+    recorders: [recordCIP25, recordCIP68, recordForge, recordCIP27],
     rollbacks: [],
     onClose: async () => {
       logger.error("Onchain recording stopped unexpectedly");

--- a/src/onchain/recorders/cip27.ts
+++ b/src/onchain/recorders/cip27.ts
@@ -1,0 +1,74 @@
+import _ from "lodash";
+import { CIP27Royalty } from "../../db/models";
+import { logger } from "../../logger";
+import { joinStringIfNeeded, parseMetadatumLossy, Recorder, SupportedTx } from "./utils";
+
+const CIP_27_METADATUM_LABEL = "777";
+
+export const recordCIP27: Recorder = async (block, dbBlock) => {
+  const transactions: SupportedTx[] = block.body;
+
+  const cip27Transactions = transactions.filter(
+    (tx) => !!tx.body.mint.assets && _.has(tx.metadata?.body.blob, CIP_27_METADATUM_LABEL)
+  );
+
+  if (cip27Transactions.length === 0) {
+    return;
+  }
+
+  const policyIdsWithRoyalties = _.compact(
+    cip27Transactions.map((tx) => {
+      const royaltyTokens = _.entries(tx.body.mint.assets)
+        .filter(([unit, qty]) => BigInt(qty) === 1n && !unit.split(".")[1] /* there is no asset name */)
+        .map(([unit]) => unit.split(".")[0]);
+
+      const royaltyMetadatum = tx.metadata?.body.blob?.[CIP_27_METADATUM_LABEL];
+
+      // in a single tx there can be at most 1 royalty token
+      if (royaltyTokens.length !== 1 || !royaltyMetadatum) {
+        logger.warn({ royaltyMetadatum, royaltyTokens }, "Invalid CIP27 transaction");
+        return null;
+      }
+
+      const policyId = royaltyTokens[0];
+
+      const metadata = parseMetadatumLossy(royaltyMetadatum);
+
+      if (!_.isObject(metadata)) {
+        logger.warn({ royaltyMetadatum }, "Invalid CIP27 metadata");
+        return null;
+      }
+
+      const rate = metadata["rate"] || metadata["pct"];
+      const addr = joinStringIfNeeded(metadata["addr"] || metadata["address"]);
+
+      if (_.isString(rate) && _.isString(addr)) {
+        return {
+          policyId,
+          rate,
+          addr,
+        };
+      } else {
+        logger.warn({ addr, rate }, "CIP27 metadata is missing required fields");
+        return null;
+      }
+    })
+  );
+
+  if (policyIdsWithRoyalties.length === 0) {
+    return;
+  }
+
+  await CIP27Royalty.bulkCreate(
+    policyIdsWithRoyalties.map(({ policyId, rate, addr }) => ({
+      policyId,
+      rate,
+      addr,
+      BlockId: dbBlock.id,
+    })),
+    {
+      ignoreDuplicates: true,
+    }
+  );
+  logger.debug({ royaltyCount: policyIdsWithRoyalties }, "Inserted royalties for policies");
+};


### PR DESCRIPTION
fixes #8 

Doesn't really validate if the policy is actually used for nfts. In general if there is some royalty metadata associated with a policy, it will be included in the query results.